### PR TITLE
feat: adding specific IndslUserWarning [AH-2555]

### DIFF
--- a/indsl/equipment/volume_vessel.py
+++ b/indsl/equipment/volume_vessel.py
@@ -10,6 +10,7 @@ import pandas as pd
 from indsl.exceptions import FLUIDS_REQUIRED
 from indsl.resample.auto_align import auto_align
 from indsl.type_check import check_types
+from indsl.warnings import IndslUserWarning
 
 
 NUMBA_DISABLED = os.environ.get("NUMBA_DISABLE_JIT") == "1"
@@ -29,7 +30,8 @@ else:
             import fluids.vectorized as fv
         except ImportError as e:
             warnings.warn(
-                f"Couldn't import fluids.numba_vectorized: {e!s}. Default to import fluids.vectorized.", UserWarning
+                f"Couldn't import fluids.numba_vectorized: {e!s}. Default to import fluids.vectorized.",
+                category=IndslUserWarning,
             )
             fv = None  # Only core dependencies available. Will raise an error later
 

--- a/indsl/resample/interpolate.py
+++ b/indsl/resample/interpolate.py
@@ -12,6 +12,7 @@ from indsl import versioning
 from indsl.exceptions import UserValueError
 from indsl.ts_utils.ts_utils import functional_mean, is_na_all
 from indsl.type_check import check_types
+from indsl.warnings import IndslUserWarning
 
 from . import interpolate_v1  # noqa
 
@@ -65,7 +66,7 @@ def interpolate(
     """
     # Check if all values are NaN
     if is_na_all(data):
-        warnings.warn("All values in the time series are NaN.", UserWarning)
+        warnings.warn("All values in the time series are NaN.", category=IndslUserWarning)
         return data
 
     # Allow for other ways of defining forward filling for stepwise functions
@@ -92,7 +93,7 @@ def interpolate(
 
     # Check for empty time series
     if len(observations) < 2:
-        warnings.warn("The time series contains less than two values.", UserWarning)
+        warnings.warn("The time series contains less than two values.", category=IndslUserWarning)
         return data
 
     # x and y datapoints used to construct linear piecewise function

--- a/indsl/resample/resample.py
+++ b/indsl/resample/resample.py
@@ -13,6 +13,7 @@ from indsl.exceptions import UserTypeError
 from indsl.ts_utils.ts_utils import fill_gaps, get_fixed_freq, is_na_all
 from indsl.type_check import check_types
 from indsl.validations import validate_series_has_time_index, validate_series_is_not_empty
+from indsl.warnings import IndslUserWarning
 
 from . import resample_v1  # noqa
 
@@ -102,7 +103,8 @@ def resample(
         if not granularity_current:
             # TODO: pick max resolution and apply to the rest of the timeseries?
             warnings.warn(
-                "Can't infer time series resolution with missing data. Please provide resolution", UserWarning
+                "Can't infer time series resolution with missing data. Please provide resolution",
+                category=IndslUserWarning,
             )
             return data
 

--- a/indsl/resample/resample_v1.py
+++ b/indsl/resample/resample_v1.py
@@ -14,6 +14,7 @@ from indsl.exceptions import UserTypeError, UserValueError
 from indsl.ts_utils.ts_utils import fill_gaps, get_fixed_freq, is_na_all
 from indsl.type_check import check_types
 from indsl.validations import validate_series_has_time_index
+from indsl.warnings import IndslUserWarning
 
 
 @versioning.register(version="1.0", deprecated=True)
@@ -102,7 +103,8 @@ def resample(
         if not granularity_current:
             # TODO: pick max resolution and apply to the rest of the timeseries?
             warnings.warn(
-                "Can't infer time series resolution with missing data. Please provide resolution", UserWarning
+                "Can't infer time series resolution with missing data. Please provide resolution",
+                category=IndslUserWarning,
             )
             return data
 

--- a/indsl/signals/generator.py
+++ b/indsl/signals/generator.py
@@ -11,6 +11,7 @@ from indsl.signals.noise import RedNoise, Sinusoidal, TimeSampler, TimeSeries
 from indsl.ts_utils.utility_functions import TimeUnits
 from indsl.type_check import check_types
 from indsl.validations import validate_series_has_time_index
+from indsl.warnings import IndslUserWarning
 
 
 @check_types
@@ -574,7 +575,9 @@ def _make_index(
     # Catch strange sample frequency inputs
     if not isinstance(freq, pd.Timedelta):
         freq = pd.Timedelta(1, "m")
-        warnings.warn("Can't recognize the sample frequency, setting it to the '1 m' default.")
+        warnings.warn(
+            "Can't recognize the sample frequency, setting it to the '1 m' default.", category=IndslUserWarning
+        )
 
     if freq.total_seconds() <= 0:
         raise UserValueError(

--- a/indsl/statistics/outliers_v1.py
+++ b/indsl/statistics/outliers_v1.py
@@ -10,6 +10,7 @@ from indsl import versioning
 from indsl.exceptions import CSAPS_REQUIRED, KNEED_REQUIRED, SCIKIT_LEARN_REQUIRED, UserValueError
 from indsl.type_check import check_types
 from indsl.validations import validate_series_has_time_index, validate_series_is_not_empty
+from indsl.warnings import IndslUserWarning
 
 
 @versioning.register(version="1.0", deprecated=True)
@@ -220,7 +221,7 @@ def _get_outlier_indices(
     if str.isdigit(time_window):  # if user gives '60' it will be considered as '60min'
         warnings.warn(
             f"Missing time unit in argument 'time_window' in remove_outliers function, assuming {time_window}min.",
-            UserWarning,
+            category=IndslUserWarning,
         )
         time_window = str(time_window) + "min"
 

--- a/indsl/ts_utils/ts_utils.py
+++ b/indsl/ts_utils/ts_utils.py
@@ -11,6 +11,7 @@ import scipy.integrate
 
 from indsl.exceptions import UserRuntimeError, UserValueError
 from indsl.type_check import check_types
+from indsl.warnings import IndslUserWarning
 
 
 _unit_in_ms_without_week = {"s": 1000, "m": 60000, "h": 3600000, "d": 86400000}
@@ -292,8 +293,8 @@ def time_parse(time_window: str = "60min", function_name: str = "") -> pd.Timede
     """
     if str.isdigit(time_window):  # if user gives '60' it will be considered as '60min'
         warnings.warn(
-            f"Missing time unit in argument 'time_window' in {function_name} function, assuming {time_window}min.",
-            UserWarning,
+            f"Missing time unit in argument 'time_window' in {function_name} function, assuming {time_window} min.",
+            category=IndslUserWarning,
         )
         time_window = str(time_window) + "min"
     try:

--- a/indsl/warnings.py
+++ b/indsl/warnings.py
@@ -1,3 +1,2 @@
 class IndslUserWarning(UserWarning):
     """Warning that will be shown to the user."""
-

--- a/indsl/warnings.py
+++ b/indsl/warnings.py
@@ -1,0 +1,5 @@
+class IndslUserWarning(UserWarning):
+    """Warning that will be shown to the user."""
+
+    def __init__(self, message):
+        self.message = message

--- a/indsl/warnings.py
+++ b/indsl/warnings.py
@@ -1,5 +1,4 @@
 class IndslUserWarning(UserWarning):
     """Warning that will be shown to the user."""
 
-    def __init__(self, message):
-        self.message = message
+    pass

--- a/indsl/warnings.py
+++ b/indsl/warnings.py
@@ -1,4 +1,3 @@
 class IndslUserWarning(UserWarning):
     """Warning that will be shown to the user."""
 
-    pass

--- a/tests/resample/test_interpolate.py
+++ b/tests/resample/test_interpolate.py
@@ -4,6 +4,7 @@ import pandas as pd
 import pytest
 
 from indsl.resample.interpolate import interpolate
+from indsl.warnings import IndslUserWarning
 
 from ..generate_data import create_non_uniform_data, create_uniform_data, set_na_random_data
 
@@ -17,14 +18,14 @@ from ..generate_data import create_non_uniform_data, create_uniform_data, set_na
     ],
 )
 def test_too_few_data_warnings(input):
-    with pytest.warns(UserWarning):
+    with pytest.warns(IndslUserWarning):
         interpolated_data = interpolate(input)
         assert len(interpolated_data) == len(input)
 
 
 # Test for all NaN data
 def test_all_nan_data():
-    with pytest.warns(UserWarning):
+    with pytest.warns(IndslUserWarning):
         test_data = create_uniform_data(np.ones(10) * np.nan)
         interpolated_data = interpolate(test_data)
         assert len(interpolated_data) == len(test_data)

--- a/tests/signals/test_signal_generator.py
+++ b/tests/signals/test_signal_generator.py
@@ -16,7 +16,7 @@ from indsl.signals.generator import (
     perturb_timestamp,
     sine_wave,
 )
-
+from indsl.warnings import IndslUserWarning
 
 test_data_4index = [
     ("1975/5/9", "1975-5-10", pd.Timedelta("1s"), 1.0, pd.Timedelta("1 day")),
@@ -33,7 +33,7 @@ test_data_warns = [
 
 @pytest.mark.parametrize("bad_rate", [(-99999), (None)])
 def test_wrong_sample_rate(bad_rate):
-    with pytest.warns(UserWarning):
+    with pytest.warns(IndslUserWarning):
         _make_index(freq=bad_rate)
 
 
@@ -65,7 +65,7 @@ def test_index_generator(start_date, end_date, sample_rate, expected_mean, expec
     test_data_warns,
 )
 def test_sample_freq_warns(start_date, end_date, sample_rate, expected_mean, expected_dt):
-    with pytest.warns(UserWarning):
+    with pytest.warns(IndslUserWarning):
         # Test that the generated DatetimeIndex has the correct sampling frequency and duration based on input parameters
         idx = _make_index(start=start_date, end=end_date, freq=sample_rate)
         # Convert to time, where t=0 is idx[0]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
adding specific IndslUserWarning such that it would be easy for backend to know if the warning comes from Indsl and it should be shown to the user, or that it should be ignored.


## Motivation and Context
Currently we do not have ability to check if warning comes from the 3rd source API or Indsl. With this change we will be able to show only warnings that comes from Indsl to the user. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

## Contributor Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have added an example of my new feature and included it in the documentation.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** [document](https://cognitedata.github.io/indsl/contribute.html).
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] My Pull Request name follows the [naming convention](https://www.conventionalcommits.org/en/v1.0.0/) `fix: <description>`, `feat: <description>`, etc.

## Reviewer Checklist for Charts compliant functions:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The docstrings of the new function follow the contributing [guidelines](https://cognitedata.github.io/indsl/contribute.html).
- [ ] The new function is professionally [documented](https://journal.emwa.org/writing-matters/whats-your-problem-a-practical-approach-to-scientific-document-design/article/2110/2047480612z2e00000000042.pdf)
- [ ] The new function and associated scripts are covered by one or more unit tests and code coverage did not decrease.
- [ ] The new function is accompanied by an example and it is included in the Gallery of Charts.
- [ ] The new function is reviewed in Chromatic. Access the storybook build results url and comment, approve or deny.
- [ ] All function inputs, arguments, and outputs have a supported data type and have human readable names.
- [ ] No code language is included in the description of the function or parameters (e.g use "polynomial order" instead of "poly_order")

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->


[AH-2555]: https://cognitedata.atlassian.net/browse/AH-2555?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ