### PR TITLE
chore: version 8.8.1 → 8.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,21 @@
 ## v8.9.0 (2026-04-17)
 
+### Feat
+
+- Add Python 3.14 support (#523)
+
 ### Fix
 
-- align version files with last released tag v8.8.1
-- **deps**: update dependency pandas to v3 - abandoned (#571)
+- **deps**: update dependency pandas to ~3.0.1 (#571)
 - **deps**: update dependency numba to >=0.65,<0.66 (#602)
-- **deps**: update python to v3.14.2 (#523)
 - **deps**: update dependency scipy to ~1.17.0 (#560)
 - **deps**: update dependency scikit-image to ^0.26.0 (#559)
 - **deps**: update urllib3 to 2.6.3 (CVE-2026-21441) (#546)
 - **deps**: update dependency numba to ^0.62.0 (#520)
-- Fixing auto examples (#507)
+
+### Chore
+
+- Migrate build system from Poetry to uv (#585)
 
 ## v8.8.0 (2025-09-30)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## v8.9.0 (2026-04-17)
+
+### Fix
+
+- align version files with last released tag v8.8.1
+- **deps**: update dependency pandas to v3 - abandoned (#571)
+- **deps**: update dependency numba to >=0.65,<0.66 (#602)
+- **deps**: update python to v3.14.2 (#523)
+- **deps**: update dependency scipy to ~1.17.0 (#560)
+- **deps**: update dependency scikit-image to ^0.26.0 (#559)
+- **deps**: update urllib3 to 2.6.3 (CVE-2026-21441) (#546)
+- **deps**: update dependency numba to ^0.62.0 (#520)
+- Fixing auto examples (#507)
+
 ## v8.8.0 (2025-09-30)
 
 ### Feat

--- a/indsl/_version.py
+++ b/indsl/_version.py
@@ -1,2 +1,2 @@
 # Copyright 2023 Cognite AS
-__version__ = "8.8.1"
+__version__ = "8.9.0"

--- a/indsl/_version.py
+++ b/indsl/_version.py
@@ -1,2 +1,2 @@
 # Copyright 2023 Cognite AS
-__version__ = "0.0.0"
+__version__ = "8.8.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "indsl"
-version = "8.8.1"
+version = "8.9.0"
 description = "Industrial Data Science Library by Cognite"
 authors = [{ name = "Cognite" }]
 license = { text = "Apache-2.0" }
@@ -114,7 +114,7 @@ known-third-party = ["pytest"]
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "8.8.1"
+version = "8.9.0"
 tag_format = "v$version"
 version_provider = "pep621"
 version_files = ["pyproject.toml:version", "indsl/_version.py:__version__"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "indsl"
-version = "8.8.0"
+version = "8.8.1"
 description = "Industrial Data Science Library by Cognite"
 authors = [{ name = "Cognite" }]
 license = { text = "Apache-2.0" }
@@ -114,7 +114,7 @@ known-third-party = ["pytest"]
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "8.8.0"
+version = "8.8.1"
 tag_format = "v$version"
 version_provider = "pep621"
 version_files = ["pyproject.toml:version", "indsl/_version.py:__version__"]

--- a/uv.lock
+++ b/uv.lock
@@ -820,7 +820,7 @@ wheels = [
 
 [[package]]
 name = "indsl"
-version = "8.8.0"
+version = "8.8.1"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
## Summary

- Adds Python 3.14 support
- Migrates build system from Poetry to uv
- Updates pandas ~3.0.1, scipy ~1.17.0, numba >=0.65, scikit-image ^0.26.0, urllib3 2.6.3 (CVE-2026-21441)

## Release notes (v8.9.0)

### Feat
- Add Python 3.14 support (#523)

### Fix
- **deps**: update dependency pandas to ~3.0.1 (#571)
- **deps**: update dependency numba to >=0.65,<0.66 (#602)
- **deps**: update dependency scipy to ~1.17.0 (#560)
- **deps**: update dependency scikit-image to ^0.26.0 (#559)
- **deps**: update urllib3 to 2.6.3 (CVE-2026-21441) (#546)
- **deps**: update dependency numba to ^0.62.0 (#520)

### Chore
- Migrate build system from Poetry to uv (#585)

## After merge

1. Create a GitHub release selecting tag `v8.9.0` — this triggers the PyPI publish workflow
2. Run `build_docs.sh` and open a separate `build-docs` PR