### PR TITLE
ci(docs): publish docs from GitHub Actions instead of main:/docs

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -33,7 +33,7 @@ jobs:
           python-version: '3.14'
 
       - name: Install dependencies
-        run: uv sync --group docs --all-extras
+        run: uv sync --group docs --all-extras --frozen
 
       - name: Regenerate docs CHANGELOG
         run: printf '# Changelog\n\n%s\n' "$(cat CHANGELOG.md)" > docs-source/source/CHANGELOG.md

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,69 @@
+name: Build and deploy docs
+
+on:
+  release:
+    types: [created]
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'docs-source/**'
+      - 'CHANGELOG.md'
+      - '.github/workflows/docs.yaml'
+      - 'indsl/**'
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: Build docs
+    steps:
+      - name: Check out
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: '3.14'
+
+      - name: Install dependencies
+        run: uv sync --group docs --all-extras
+
+      - name: Regenerate docs CHANGELOG
+        run: printf '# Changelog\n\n%s\n' "$(cat CHANGELOG.md)" > docs-source/source/CHANGELOG.md
+
+      - name: Build HTML
+        working-directory: docs-source
+        run: uv run make html
+
+      - name: Inject Pages metadata
+        run: |
+          touch docs-source/build/html/.nojekyll
+          echo 'indsl.docs.cognite.com' > docs-source/build/html/CNAME
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs-source/build/html
+
+  deploy:
+    needs: build
+    if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    name: Deploy to GitHub Pages
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary

- Add `.github/workflows/docs.yaml` that builds the Sphinx site in CI and deploys via the **GitHub Actions** Pages source.
- Replaces the manual `build_docs.sh` → `build-docs` branch → PR-into-main publishing flow.
- PRs that touch docs sources run the build only (no deploy); releases and `workflow_dispatch` also deploy.

## Why

Today's flow checks built HTML into `main:/docs`, which produces ~317-file release PRs that drown reviewers (see #614) and lets partial local builds reach production. Moving docs to a CI-built artifact removes generated files from `main` entirely and eliminates human-in-the-loop publishing.

This PR is **only the workflow**. Cleanup of `docs/`, `build_docs.sh`, and the `build-docs` branch is a separate follow-up PR, intentionally held until the new pipeline is verified live so rollback (Pages source → `main:/docs`) stays a single click.

## Workflow shape

- Mirrors `publish.yaml`'s setup: pinned `actions/checkout@v6`, `astral-sh/setup-uv@v7`, Python 3.14.
- Ports build steps verbatim from `build_docs.sh`: `printf` CHANGELOG regen, `uv sync --group docs --all-extras`, `uv run make html`.
- Re-emits `.nojekyll` and `CNAME` (`indsl.docs.cognite.com`) into the artifact so custom-domain config survives every deploy.
- `concurrency: pages` guards against racing deploys.

## Manual cutover (after merge)

1. Actions → Run `Build and deploy docs` on `main`. Verify green; spot-check the artifact.
2. Settings → Pages → **Source: GitHub Actions**.
3. Settings → Pages → re-enter custom domain `indsl.docs.cognite.com`; enable "Enforce HTTPS" once it appears.
4. Verify https://indsl.docs.cognite.com/ serves the new build.
5. Open follow-up cleanup PR.

Expected downtime: best case zero, realistic 5–15 min during the cert re-bind. Rollback: flip Pages source back to `main:/docs` (one click; `docs/` still present until the cleanup PR).

## Test plan

- [ ] PR's `build` job passes (this PR doesn't touch `docs-source/**`, so the build job won't be triggered by paths — confirm by running `workflow_dispatch` on this branch once merged, or temporarily allow the workflow to run on this PR for verification)
- [ ] Manual `workflow_dispatch` run on `main` post-merge produces a valid artifact
- [ ] Post-cutover: `/`, `/CHANGELOG.html`, `/auto_examples/statistics/plot_remove_outliers.html` all render correctly