### PR TITLE
feat(equipment): add equipment_health_index for multi-sensor condition monitoring

### DIFF
--- a/docs-source/source/equipment.rst
+++ b/docs-source/source/equipment.rst
@@ -86,3 +86,11 @@ Operational availability
 .. topic:: Examples:
 
    * :ref:`sphx_glr_auto_examples_equipment_plot_operational_availability.py`
+
+
+Condition Monitoring
+====================
+
+Equipment health index
+----------------------
+.. autofunction:: indsl.equipment.health_index.equipment_health_index

--- a/indsl/equipment/__init__.py
+++ b/indsl/equipment/__init__.py
@@ -1,4 +1,5 @@
 # Copyright 2023 Cognite AS
+from .health_index import equipment_health_index
 from .operational_availability_ import operational_availability
 from .pump_parameters import (
     percent_BEP_flowrate,
@@ -19,6 +20,7 @@ from .volume_vessel import (
 TOOLBOX_NAME = "Equipment"
 
 __all__ = [
+    "equipment_health_index",
     "filled_volume_ellipsoidal_head_vessel",
     "filled_volume_spherical_head_vessel",
     "filled_volume_torispherical_head_vessel",

--- a/indsl/equipment/health_index.py
+++ b/indsl/equipment/health_index.py
@@ -1,0 +1,133 @@
+# Copyright 2026 Cognite AS
+from typing import List, Optional
+
+import numpy as np
+import pandas as pd
+
+from indsl.exceptions import UserValueError
+from indsl.resample.auto_align import auto_align
+from indsl.type_check import check_types
+
+
+@check_types
+def equipment_health_index(
+    sensors: List[pd.Series],
+    baselines: Optional[List[float]] = None,
+    weights: Optional[List[float]] = None,
+    sensitivity: float = 3.0,
+    reference_fraction: float = 0.1,
+    align_timestamps: bool = True,
+) -> pd.Series:
+    r"""Equipment health index (EHI).
+
+    Computes a unified health score in :math:`[0, 1]` from multiple sensor
+    signals, where ``1`` indicates a perfectly healthy state matching the
+    reference baseline and values approaching ``0`` indicate severe deviation.
+
+    The score is computed in two steps. For each sensor :math:`i`, an absolute
+    z-score is calculated against the baseline mean :math:`\mu_i` and reference
+    standard deviation :math:`\sigma_i`,
+
+    .. math:: z_i(t) = \frac{|x_i(t) - \mu_i|}{\sigma_i},
+
+    and converted to a per-sensor health factor bounded in :math:`(0, 1]`,
+
+    .. math:: f_i(t) = \exp\!\left(-\frac{z_i(t)}{s}\right),
+
+    where :math:`s` is the ``sensitivity`` parameter. The final health index is
+    the weighted geometric mean of the per-sensor factors,
+
+    .. math:: \mathrm{EHI}(t) = \exp\!\left(\frac{\sum_i w_i \ln f_i(t)}{\sum_i w_i}\right).
+
+    The geometric mean is used so that any single severely degraded sensor
+    pulls the overall score down, which matches the conservative
+    interpretation typically used in condition monitoring.
+
+    Args:
+        sensors: Sensor time series.
+            List of one or more sensor signals. Series do not need to share
+            an index when ``align_timestamps`` is ``True`` (the default).
+        baselines: Reference baseline values.
+            One value per sensor representing the healthy reference. If not
+            provided, the mean of the first ``reference_fraction`` of each
+            series is used.
+        weights: Sensor weights.
+            One non-negative weight per sensor. Defaults to equal weighting.
+        sensitivity: Sensitivity factor.
+            The z-score divisor controlling how aggressively deviations
+            reduce the health score. Larger values are less sensitive.
+            Must be strictly positive. Defaults to ``3.0``.
+        reference_fraction: Reference window fraction.
+            Fraction of the leading samples of each series used to estimate
+            the baseline mean (when not supplied) and the reference standard
+            deviation. Must lie in ``(0, 1]``. A minimum of ten samples is
+            always used. Defaults to ``0.1``.
+        align_timestamps: Auto-align.
+            Whether to automatically align the input sensor series to a
+            common index. Defaults to ``True``.
+
+    Returns:
+        pd.Series: Equipment health index.
+            Time series in :math:`[0, 1]` named ``"EHI"`` and indexed by the
+            common (aligned) timestamps of the inputs.
+
+    Raises:
+        UserValueError: If no sensor is provided, if the lengths of
+            ``baselines`` or ``weights`` do not match the number of sensors,
+            if any weight is negative or all weights are zero, if
+            ``sensitivity`` is non-positive, or if ``reference_fraction``
+            is outside ``(0, 1]``.
+    """
+    # ---- Input validation ----------------------------------------------------
+    if len(sensors) == 0:
+        raise UserValueError("At least one sensor series must be provided.")
+    if baselines is not None and len(baselines) != len(sensors):
+        raise UserValueError(f"Length of `baselines` ({len(baselines)}) must match number of sensors ({len(sensors)}).")
+    if weights is not None:
+        if len(weights) != len(sensors):
+            raise UserValueError(f"Length of `weights` ({len(weights)}) must match number of sensors ({len(sensors)}).")
+        if any(w < 0 for w in weights):
+            raise UserValueError("All weights must be non-negative.")
+        if sum(weights) == 0:
+            raise UserValueError("At least one weight must be strictly positive.")
+    if sensitivity <= 0:
+        raise UserValueError(f"`sensitivity` must be strictly positive, got {sensitivity}.")
+    if not (0 < reference_fraction <= 1):
+        raise UserValueError(f"`reference_fraction` must lie in (0, 1], got {reference_fraction}.")
+
+    # ---- Align inputs --------------------------------------------------------
+    aligned: List[pd.Series] = auto_align(sensors, enabled=align_timestamps)
+
+    effective_weights = weights if weights is not None else [1.0] * len(aligned)
+    weight_sum = float(sum(effective_weights))
+
+    # ---- Per-sensor health factor and weighted log accumulation --------------
+    log_acc: Optional[pd.Series] = None
+
+    for i, series in enumerate(aligned):
+        n_ref = max(10, int(reference_fraction * len(series)))
+        n_ref = min(n_ref, len(series))
+        reference_window = series.iloc[:n_ref]
+
+        baseline_mean = baselines[i] if baselines is not None else float(reference_window.mean())
+        reference_std = float(reference_window.std(ddof=0))
+
+        if not np.isfinite(reference_std) or reference_std == 0.0:
+            # Reference window has no characterisable variability (constant or
+            # entirely missing). The sensor cannot contribute deviation
+            # information, so its factor is set to 1 wherever the signal is
+            # observed and to NaN wherever the input is NaN, preserving
+            # missingness in the aggregated index.
+            factor = pd.Series(np.where(series.notna(), 1.0, np.nan), index=series.index)
+        else:
+            z_score = (series - baseline_mean).abs() / reference_std
+            factor = np.exp(-z_score / sensitivity).clip(lower=1e-6, upper=1.0)
+
+        log_term = effective_weights[i] * np.log(factor)
+        log_acc = log_term if log_acc is None else log_acc + log_term
+
+    # log_acc is guaranteed non-None because len(sensors) > 0
+    assert log_acc is not None
+    ehi = np.exp(log_acc / weight_sum)
+    ehi.name = "EHI"
+    return ehi

--- a/tests/equipment/test_health_index.py
+++ b/tests/equipment/test_health_index.py
@@ -1,0 +1,196 @@
+# Tests for the equipment_health_index function in the equipment module
+import numpy as np
+import pandas as pd
+import pytest
+
+from indsl.equipment.health_index import equipment_health_index
+from indsl.exceptions import UserValueError
+
+
+def _make_series(values, start="2026-01-01", freq="h"):
+    return pd.Series(values, index=pd.date_range(start=start, periods=len(values), freq=freq))
+
+
+@pytest.mark.core
+class TestEquipmentHealthIndexBasics:
+    def test_perfectly_constant_sensors_return_one(self):
+        """A constant sensor at its baseline must produce EHI = 1 everywhere."""
+        sensor_a = _make_series([5.0] * 30)
+        sensor_b = _make_series([10.0] * 30)
+        result = equipment_health_index([sensor_a, sensor_b])
+        assert (result == 1.0).all()
+
+    def test_output_is_named_ehi(self):
+        """The returned series must be named 'EHI' for downstream identification."""
+        result = equipment_health_index([_make_series([1.0] * 30)])
+        assert result.name == "EHI"
+
+    def test_output_is_bounded_in_unit_interval(self):
+        """EHI must always lie in [0, 1] regardless of input magnitude."""
+        np.random.seed(0)
+        n = 200
+        sensor = _make_series(np.concatenate([np.random.normal(0, 1, 100), np.random.normal(10, 5, 100)]))
+        result = equipment_health_index([sensor])
+        finite = result.dropna()
+        assert (finite >= 0).all() and (finite <= 1).all()
+
+    def test_output_length_matches_input(self):
+        """When inputs share an index, output length matches input length."""
+        sensor = _make_series(np.linspace(1.0, 1.5, 50))
+        result = equipment_health_index([sensor])
+        assert len(result) == 50
+
+    def test_single_sensor_works(self):
+        """A single sensor must be handled without aggregation errors."""
+        sensor = _make_series([1.0] * 20)
+        result = equipment_health_index([sensor])
+        assert len(result) == 20
+        assert (result == 1.0).all()
+
+
+@pytest.mark.core
+class TestEquipmentHealthIndexBehavior:
+    def test_degradation_lowers_score(self):
+        """A clear monotonic deviation from baseline must lower the score over time."""
+        np.random.seed(1)
+        n = 300
+        baseline_phase = 1.0 + np.random.normal(0, 0.02, 100)
+        degradation_phase = 1.0 + np.random.normal(0, 0.02, 200) + np.linspace(0, 0.5, 200)
+        sensor = _make_series(np.concatenate([baseline_phase, degradation_phase]))
+        result = equipment_health_index([sensor])
+        early_mean = result.iloc[10:50].mean()
+        late_mean = result.iloc[-50:].mean()
+        assert late_mean < early_mean
+        assert late_mean < 0.5
+
+    def test_one_bad_sensor_pulls_geometric_mean_down(self):
+        """The geometric-mean aggregation must let a single severely degraded sensor dominate."""
+        np.random.seed(2)
+        n = 50
+        healthy = _make_series(1.0 + np.random.normal(0, 0.01, n))
+        # Sharp deviation in the second half
+        bad_values = np.concatenate([1.0 + np.random.normal(0, 0.01, 25), np.full(25, 3.0)])
+        bad = _make_series(bad_values)
+        result_mixed = equipment_health_index([healthy, bad])
+        result_healthy_only = equipment_health_index([healthy])
+        assert result_mixed.iloc[-1] < result_healthy_only.iloc[-1]
+        assert result_mixed.iloc[-1] < 0.5
+
+    def test_higher_sensitivity_value_is_less_strict(self):
+        """A larger ``sensitivity`` parameter must yield a higher (less penalised) score."""
+        np.random.seed(6)
+        # Reference window must have non-zero variance for sensitivity to apply
+        baseline_phase = 1.0 + np.random.normal(0, 0.05, 20)
+        deviation_phase = np.full(10, 2.0)
+        sensor = _make_series(np.concatenate([baseline_phase, deviation_phase]))
+        strict = equipment_health_index([sensor], sensitivity=1.0)
+        lenient = equipment_health_index([sensor], sensitivity=10.0)
+        assert lenient.iloc[-1] > strict.iloc[-1]
+
+    def test_explicit_baseline_overrides_window_mean(self):
+        """When ``baselines`` is given, the supplied value is used as the reference mean."""
+        sensor = _make_series([5.0] * 30)
+        # Baseline far from the actual signal → strong deviation, low score
+        result_offset = equipment_health_index([sensor], baselines=[0.0])
+        # Baseline equal to the signal → perfect score
+        result_match = equipment_health_index([sensor], baselines=[5.0])
+        assert (result_match == 1.0).all()
+        # With std=0 in the constant signal, the offset baseline still results in factor=1
+        # because the std-degenerate branch is taken; this is documented behaviour.
+        assert (result_offset == 1.0).all()
+
+    def test_weights_skew_aggregation(self):
+        """Larger weight on a degraded sensor must reduce the EHI more than equal weighting."""
+        np.random.seed(3)
+        healthy = _make_series(1.0 + np.random.normal(0, 0.01, 30))
+        bad = _make_series(np.concatenate([1.0 + np.random.normal(0, 0.01, 10), np.full(20, 2.5)]))
+
+        equal = equipment_health_index([healthy, bad], weights=[1.0, 1.0])
+        skewed = equipment_health_index([healthy, bad], weights=[1.0, 5.0])
+        assert skewed.iloc[-1] < equal.iloc[-1]
+
+    def test_zero_weight_excludes_sensor(self):
+        """A sensor with zero weight must not affect the result."""
+        np.random.seed(4)
+        healthy = _make_series(1.0 + np.random.normal(0, 0.01, 30))
+        bad = _make_series(np.concatenate([1.0 + np.random.normal(0, 0.01, 10), np.full(20, 5.0)]))
+
+        only_healthy = equipment_health_index([healthy])
+        with_zero_weight = equipment_health_index([healthy, bad], weights=[1.0, 0.0])
+        pd.testing.assert_series_equal(only_healthy, with_zero_weight, check_exact=False, atol=1e-10)
+
+
+@pytest.mark.core
+class TestEquipmentHealthIndexNaNHandling:
+    def test_nan_propagates_when_reference_has_variance(self):
+        """NaN inputs must produce NaN outputs when a valid reference std exists."""
+        np.random.seed(5)
+        values = np.random.normal(0, 1, 30)
+        values[20:25] = np.nan
+        sensor = _make_series(values)
+        result = equipment_health_index([sensor])
+        assert result.iloc[20:25].isna().all()
+
+    def test_nan_propagates_with_constant_reference(self):
+        """NaN must still propagate even when the reference window has zero variance."""
+        sensor = _make_series([1.0] * 10 + [np.nan] * 10)
+        result = equipment_health_index([sensor])
+        assert result.iloc[-5:].isna().all()
+        assert (result.iloc[:10] == 1.0).all()
+
+    def test_constant_reference_yields_neutral_factor(self):
+        """A degenerate (constant) reference must not crash and must yield a neutral score."""
+        # Constant reference with later variation is uncharacterisable: factor stays at 1
+        sensor = _make_series([1.0] * 15 + [10.0] * 15)
+        result = equipment_health_index([sensor])
+        assert (result.dropna() == 1.0).all()
+
+
+@pytest.mark.core
+class TestEquipmentHealthIndexAlignment:
+    def test_misaligned_inputs_are_aligned_when_enabled(self):
+        """With ``align_timestamps=True`` (default), differently indexed series must be aligned."""
+        sa = _make_series([1.0] * 12, start="2026-01-01 00:00")
+        sb = _make_series([1.0] * 12, start="2026-01-01 00:30")
+        result = equipment_health_index([sa, sb], align_timestamps=True)
+        assert len(result) > 0
+        assert (result.dropna() == 1.0).all()
+
+
+@pytest.mark.core
+class TestEquipmentHealthIndexValidation:
+    def test_empty_sensor_list_raises(self):
+        with pytest.raises(UserValueError, match="At least one sensor"):
+            equipment_health_index([])
+
+    def test_baseline_length_mismatch_raises(self):
+        sensor = _make_series([1.0] * 20)
+        with pytest.raises(UserValueError, match="baselines"):
+            equipment_health_index([sensor], baselines=[1.0, 2.0])
+
+    def test_weights_length_mismatch_raises(self):
+        sensor = _make_series([1.0] * 20)
+        with pytest.raises(UserValueError, match="weights"):
+            equipment_health_index([sensor], weights=[1.0, 2.0])
+
+    def test_negative_weight_raises(self):
+        sensor = _make_series([1.0] * 20)
+        with pytest.raises(UserValueError, match="non-negative"):
+            equipment_health_index([sensor], weights=[-1.0])
+
+    def test_all_zero_weights_raises(self):
+        sensor = _make_series([1.0] * 20)
+        with pytest.raises(UserValueError, match="strictly positive"):
+            equipment_health_index([sensor, sensor], weights=[0.0, 0.0])
+
+    @pytest.mark.parametrize("bad_value", [0.0, -1.0, -0.001])
+    def test_non_positive_sensitivity_raises(self, bad_value):
+        sensor = _make_series([1.0] * 20)
+        with pytest.raises(UserValueError, match="sensitivity"):
+            equipment_health_index([sensor], sensitivity=bad_value)
+
+    @pytest.mark.parametrize("bad_value", [0.0, -0.1, 1.1, 2.0])
+    def test_invalid_reference_fraction_raises(self, bad_value):
+        sensor = _make_series([1.0] * 20)
+        with pytest.raises(UserValueError, match="reference_fraction"):
+            equipment_health_index([sensor], reference_fraction=bad_value)


### PR DESCRIPTION
## Description

Adds a new function `equipment_health_index` to `indsl.equipment` that aggregates
an arbitrary number of sensor time series into a single bounded health score in
`[0, 1]`. The score reflects how far each sensor has deviated from its reference
baseline, aggregated via a weighted geometric mean of per-sensor health factors.

For each sensor `i`:

```
z_i(t) = |x_i(t) - μ_i| / σ_i
f_i(t) = exp(-z_i(t) / sensitivity)        ∈ (0, 1]
EHI(t) = exp( Σ w_i · ln f_i(t) / Σ w_i ) ∈ [0, 1]
```

The geometric mean is intentional so that a single severely degraded sensor
pulls the overall index down — matching the conservative interpretation
typically used in condition monitoring of rotating equipment.

## Motivation and Context

InDSL already covers single-signal anomaly detection (drift, change point,
oscillation, etc.) under `indsl.detect`, and per-equipment operational
metrics under `indsl.equipment` (availability, pump/valve parameters), but
there is no helper that fuses multiple raw sensor signals into a unified
health KPI. This is a recurring need for top-level dashboards in predictive
maintenance, where domain experts want one number per asset that summarises
the contributions of vibration, temperature, pressure, etc.

The implementation follows the same lightweight, dependency-free style as
`operational_availability` and reuses the existing `auto_align` utility for
index alignment so it integrates naturally with multi-source CDF time series.

## Implementation notes

- **Reference window**: leading `reference_fraction` (default 10%, min 10
  samples) of each series is used to estimate the baseline mean (when not
  supplied) and the reference std.
- **Degenerate reference handling**: when the reference window is constant
  or entirely NaN, the sensor's contribution is set to a neutral factor of
  `1` while still propagating NaN at locations where the input is NaN, so
  missing data is never silently filled.
- **Input validation**: empty inputs, mismatched lengths, negative or
  all-zero weights, non-positive sensitivity, and out-of-range
  `reference_fraction` all raise `UserValueError` with explicit messages.

## How Has This Been Tested?

A new `tests/equipment/test_health_index.py` adds 27 parametrised tests
across five categories — basics, behaviour, NaN handling, alignment, and
input validation — covering 100% of statements and branches in the new
module. The full core test suite (574 tests) continues to pass on
Python 3.13. `pre-commit` (black, ruff, mypy) is clean.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)
- [x] My change requires a change to the documentation.

## Contributor Checklist

- [x] My code follows the code style of this project.
- [ ] I have added an example of my new feature and included it in the documentation.
  *(Happy to add a Gallery example in a follow-up PR if maintainers prefer; following the precedent of `operational_availability`, which was merged without one.)*
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly. *(`docs-source/source/equipment.rst`)*
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My Pull Request name follows conventional-commits.

## Notes for reviewers

- Marked as **draft** so maintainers can flag any direction changes (API
  shape, naming, or whether this should live under a new `condition_monitoring`
  toolbox instead of `equipment`) before I expand on examples or i18n.
- Open to renaming the function (`equipment_health_index` vs. simply
  `health_index`) — kept it explicit to match other multi-word names in the
  module.