### PR TITLE
docs: fix docstring typos

### DIFF
--- a/indsl/data_quality/score/base.py
+++ b/indsl/data_quality/score/base.py
@@ -130,8 +130,8 @@ class DataQualityScoreAnalyser(ABC):
         """Compute data quality result.
 
         Args:
-            analysis_start: analyis start time
-            analysis_end: analyis end time
+            analysis_start: analysis start time
+            analysis_end: analysis end time
 
         Returns:
             DataQualityScore: A DataQualityScore object

--- a/indsl/data_quality/score/completeness/density.py
+++ b/indsl/data_quality/score/completeness/density.py
@@ -68,8 +68,8 @@ class DensityDataQualityScoreAnalyser(DataQualityScoreAnalyser):
         """Compute the low density analysis score.
 
         Args:
-            analysis_start: Analyis start time
-            analysis_end: Analyis end time
+            analysis_start: Analysis start time
+            analysis_end: Analysis end time
             low_density_detection_method: Low density detection method
                 Must be one of "iqr", "z_scores", "modified_z_scores", "threshold". Default to "iqr".
             low_density_detection_options: Arguments to low density detection method

--- a/indsl/data_quality/score/completeness/gap.py
+++ b/indsl/data_quality/score/completeness/gap.py
@@ -84,8 +84,8 @@ class GapDataQualityScoreAnalyser(DataQualityScoreAnalyser):
         """Calculate gap events.
 
         Args:
-            analysis_start: Analyis start time
-            analysis_end: Analyis end time
+            analysis_start: Analysis start time
+            analysis_end: Analysis end time
             gap_detection_method: Gap detection method
                 Must be one of "iqr", "z_scores", "modified_z_scores"
             gap_detection_options: Arguments to gap detection method
@@ -115,8 +115,8 @@ class GapDataQualityScoreAnalyser(DataQualityScoreAnalyser):
         """Compute the gap analysis score.
 
         Args:
-            analysis_start: Analyis start time
-            analysis_end: Analyis end time
+            analysis_start: Analysis start time
+            analysis_end: Analysis end time
             gap_detection_method: Gap detection method
                 Must be one of "iqr", "z_scores", "modified_z_scores"
             gap_detection_options: Arguments to gap detection method

--- a/indsl/ts_utils/utility_functions.py
+++ b/indsl/ts_utils/utility_functions.py
@@ -276,7 +276,7 @@ def replace(series: pd.Series, to_replace: Optional[List[float]] = None, value: 
     Args:
         series: Time series
         to_replace: Replace
-            List of values to replace. The values must be seperated by semicolons. Infinity and undefined values can be
+            List of values to replace. The values must be separated by semicolons. Infinity and undefined values can be
             replaced by using the keywords inf, -inf and nan. The default is to replace no values.
         value: Value used as replacement.
             Default is 0.0
@@ -313,7 +313,7 @@ def remove(
     Args:
         series: Time series
         to_remove: Values
-            List of values to remove. The values must be seperated by semicolons. Infinity and undefined values can be
+            List of values to remove. The values must be separated by semicolons. Infinity and undefined values can be
             replaced by using the keywords inf, -inf and nan. If empty, which is the default, all values are kept.
         range_from: Range start
             Only values above this parameter will be kept. If empty, which is the default, this range filter is deactivated.


### PR DESCRIPTION
# PR Title

docs: fix docstring typos

# PR Body

## Summary

- Fix typos in data quality score docstrings: `Analyis` / `analyis` -> `Analysis` / `analysis`
- Fix `seperated` -> `separated` in time series utility function docstrings

## Testing

- `git diff --check`

## Notes

This is a documentation-only change and does not modify runtime behavior.
