### PR TITLE
chore: bump version 8.9.0 → 8.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v8.9.1 (2026-06-23)
+
+### Fix
+
+- resolve pandas 3 DatetimeIndex-to-int64 unit regression (#639)
+- resolve deprecation and third-party warnings across test suite (#636)
+
 ## v8.9.0 (2026-04-17)
 
 ### Feat

--- a/indsl/_version.py
+++ b/indsl/_version.py
@@ -1,2 +1,2 @@
 # Copyright 2023 Cognite AS
-__version__ = "8.9.0"
+__version__ = "8.9.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "indsl"
-version = "8.9.0"
+version = "8.9.1"
 description = "Industrial Data Science Library by Cognite"
 authors = [{ name = "Cognite" }]
 license = { text = "Apache-2.0" }
@@ -94,7 +94,7 @@ known-third-party = ["pytest"]
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "8.9.0"
+version = "8.9.1"
 tag_format = "v$version"
 version_provider = "pep621"
 version_files = ["pyproject.toml:version", "indsl/_version.py:__version__"]


### PR DESCRIPTION
## Summary

- Bumps version from 8.9.0 to 8.9.1
- Updates `CHANGELOG.md` and `pyproject.toml`

## Changes in this release

- fix: resolve pandas 3 DatetimeIndex-to-int64 unit regression (#639)
- fix: resolve deprecation and third-party warnings across test suite (#636)