### PR TITLE
fix: harden release workflow to prevent tag protection bypass

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -37,9 +37,9 @@ jobs:
           PYPROJECT_VERSION=$(python -c 'import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["version"])')
           PACKAGE_VERSION=$(python -c 'from pathlib import Path; ns = {}; exec(Path("indsl/_version.py").read_text(), ns); print(ns["__version__"])')
           git fetch origin main
-          test "$TAG" = "v$PYPROJECT_VERSION"
-          test "$PACKAGE_VERSION" = "$PYPROJECT_VERSION"
-          git merge-base --is-ancestor HEAD origin/main
+          [ "$TAG" = "v$PYPROJECT_VERSION" ] || { echo "::error::release tag $TAG does not match pyproject.toml version v$PYPROJECT_VERSION"; exit 1; }
+          [ "$PACKAGE_VERSION" = "$PYPROJECT_VERSION" ] || { echo "::error::indsl/_version.py version $PACKAGE_VERSION does not match pyproject.toml version $PYPROJECT_VERSION"; exit 1; }
+          git merge-base --is-ancestor HEAD origin/main || { echo "::error::release tag commit is not an ancestor of origin/main"; exit 1; }
 
       - name: Build package
         run: uv build

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -4,16 +4,23 @@ on:
   release:
     types: [created]
 
+concurrency:
+  group: publish-${{ github.event.release.tag_name }}
+  cancel-in-progress: false
+
 jobs:
   publish:
     runs-on: ubuntu-latest
     environment: CD
+    permissions:
+      contents: read
     name: "Publish library"
     steps:
       - name: Check out
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          token: "${{ secrets.GITHUB_TOKEN }}"
+          ref: ${{ github.event.release.tag_name }}
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Install uv
@@ -23,14 +30,16 @@ jobs:
         with:
           python-version: '3.14'
 
-      - name: Install dependencies
-        run: uv sync --frozen --no-group dev
-
-      - name: Set version
+      - name: Validate release version
         run: |
-          VERSION=$(uvx dunamai from any --no-metadata --style pep440)
-          uv version $VERSION
-          echo "__version__ = \"$VERSION\"" > indsl/_version.py
+          TAG="${{ github.event.release.tag_name }}"
+          VERSION="${TAG#v}"
+          PYPROJECT_VERSION=$(python -c 'import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["version"])')
+          PACKAGE_VERSION=$(python -c 'from pathlib import Path; ns = {}; exec(Path("indsl/_version.py").read_text(), ns); print(ns["__version__"])')
+          git fetch origin main
+          test "$TAG" = "v$PYPROJECT_VERSION"
+          test "$PACKAGE_VERSION" = "$PYPROJECT_VERSION"
+          git merge-base --is-ancestor HEAD origin/main
 
       - name: Build package
         run: uv build

--- a/.gitignore
+++ b/.gitignore
@@ -145,9 +145,6 @@ test-results.xml
 localdev-*
 /localdev/
 
-# Version bump changelog
-/body.md
-
 # OS generated
 .DS_Store
 .DS_Store?

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,7 @@
 # Contributing to the library
 
 Please read about how to contribute on <https://indsl.docs.cognite.com/contribute.html>
+
+## Publishing a release
+
+See [PUBLISHING.md](./PUBLISHING.md) for the step-by-step release workflow, including how to bump the version, push the tag, and trigger the PyPI publish.

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -1,22 +1,37 @@
 [Go to the main page](./README.md)
 
 # Publishing a new version of InDSL
-The workflow for publishing the `indsl` library consists of bumping the version (1) and building the documentation (2).
-1. Bumping the version:
+The workflow for publishing the `indsl` library consists of merging a reviewed version bump PR, creating a protected release tag from `main`, and letting GitHub Actions publish the package and documentation.
+
+1. Bump the version:
     1. Delete any local branch called **bump-version**: `git branch -d bump-version`
     2. Run [bump_library.sh](./bump_library.sh)
 
-        This script will create a new commit with the `changelog` and a new `tag` following semantic versioning.
-        If you want this to be a prerelease, set an environment variable INPUT_PRERELEASE to `alpha`, `beta` or `rc` on the parameter
+        This script creates a version bump commit and updates `CHANGELOG.md` following semantic versioning. Commitizen creates a local tag during the bump, but the script deletes that tag immediately so it cannot be pushed before the PR is merged.
 
-    3. Modify the CHANGELOG.md if needed and commit the changes for `CHANGELOG.md`, `pyproject.toml`.
-    (Make sure that indsl version is updated in `pyproject.toml`)
-    4. Push the branch to github
-    5. Push the new tag to github: `git push origin --tags`
-    6. Create a PR and ask someone in the Cognite `Charts Backend` to approve and merge.
-    7. After merge, create a release in github, selecting the new tag. This will trigger the publish [workflow](./publish.yaml). This workflow will build the package and publish it to the PyPI repository
+        For a prerelease, set `INPUT_PRERELEASE` to `alpha`, `beta`, or `rc`:
 
-2. Documentation is rebuilt and published automatically when a GitHub release is created (step 1.7 above). The [Build and deploy docs](./.github/workflows/docs.yaml) workflow rebuilds the Sphinx site and deploys it to https://indsl.docs.cognite.com/ — no manual action required.
+        ```
+        INPUT_PRERELEASE=rc bash bump_library.sh
+        ```
+
+    3. Review and adjust `CHANGELOG.md`, `pyproject.toml`, and `indsl/_version.py` if needed, then commit any edits.
+    4. Push the branch to GitHub: `git push origin bump-version`
+    5. Create a PR and ask someone in the Cognite `Charts Backend` to approve and merge.
+    6. After merge, run [publish_library.sh](./publish_library.sh):
+
+        ```
+        bash publish_library.sh
+        ```
+
+        This script checks out the latest `main`, verifies the version files, creates an annotated tag on the merged `main` commit, pushes that specific tag, and creates the GitHub release from the committed changelog.
+        Requires the `gh` CLI to be authenticated.
+
+        > **Do not push tags manually.** A release tag must point to a commit that is already on `main`; otherwise it bypasses GitHub ref protection rules and triggers security alerts.
+
+        Creating the GitHub release triggers the [publish workflow](./.github/workflows/publish.yaml), which validates the release tag, builds the package, and publishes it to PyPI using the existing `PYPI_API_TOKEN` secret.
+
+2. Documentation is rebuilt and published automatically when a GitHub release is created. The [Build and deploy docs](./.github/workflows/docs.yaml) workflow rebuilds the Sphinx site and deploys it to https://indsl.docs.cognite.com/ — no manual action required.
 
 3. After the release is done, you can check the new version in the [PyPI repository](https://pypi.org/project/indsl/)
 

--- a/bump_library.sh
+++ b/bump_library.sh
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+if ! git diff --quiet || ! git diff --cached --quiet; then
+    echo "Error: tracked files have uncommitted changes. Stash or commit before bumping." >&2
+    exit 1
+fi
+
+git fetch origin main
+git checkout main
+git pull --ff-only
+
 CZ_ARGS=(--yes --changelog)
 if [ -n "${INPUT_PRERELEASE:-}" ]; then
     CZ_ARGS+=(--prerelease "$INPUT_PRERELEASE")

--- a/bump_library.sh
+++ b/bump_library.sh
@@ -1,6 +1,21 @@
-if [ $INPUT_PRERELEASE ]; then INPUT_PRERELEASE="--prerelease $INPUT_PRERELEASE"; else INPUT_PRERELEASE=''; fi
+#!/usr/bin/env bash
+set -euo pipefail
+
+CZ_ARGS=(--yes --changelog)
+if [ -n "${INPUT_PRERELEASE:-}" ]; then
+    CZ_ARGS+=(--prerelease "$INPUT_PRERELEASE")
+fi
 
 git checkout -b bump-version
 
-# create tag, create commit updating CHANGELOG.md, save changelog changes to body.md
-uv run cz bump --yes --changelog-to-stdout --changelog $INPUT_PRERELEASE > body.md
+# Commitizen creates a local tag as part of the bump. Delete it immediately so
+# the only publishable tag is created later from the merged main commit.
+uv run cz bump "${CZ_ARGS[@]}"
+
+TAG=$(git describe --tags --exact-match HEAD 2>/dev/null)
+git tag -d "$TAG" >/dev/null
+
+echo ""
+echo "Prepared release $TAG on branch bump-version."
+echo "The local tag was deleted intentionally."
+echo "After the PR is merged, run: bash publish_library.sh"

--- a/bump_library.sh
+++ b/bump_library.sh
@@ -12,8 +12,10 @@ git checkout -b bump-version
 # the only publishable tag is created later from the merged main commit.
 uv run cz bump "${CZ_ARGS[@]}"
 
-TAG=$(git describe --tags --exact-match HEAD 2>/dev/null)
-git tag -d "$TAG" >/dev/null
+TAG=$(git describe --tags --exact-match HEAD 2>/dev/null || true)
+if [ -n "$TAG" ]; then
+    git tag -d "$TAG" >/dev/null
+fi
 
 echo ""
 echo "Prepared release $TAG on branch bump-version."

--- a/bump_library.sh
+++ b/bump_library.sh
@@ -15,6 +15,8 @@ uv run cz bump "${CZ_ARGS[@]}"
 TAG=$(git describe --tags --exact-match HEAD 2>/dev/null || true)
 if [ -n "$TAG" ]; then
     git tag -d "$TAG" >/dev/null
+else
+    echo "Warning: no tag found at HEAD after cz bump — nothing to delete." >&2
 fi
 
 echo ""

--- a/publish_library.sh
+++ b/publish_library.sh
@@ -33,11 +33,11 @@ if [ "$LOCAL_MAIN" != "$REMOTE_MAIN" ]; then
     exit 1
 fi
 
-VERSION=$(python -c 'import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["version"])')
+VERSION=$(uv run python -c 'import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["version"])')
 TAG="v$VERSION"
 TITLE="InDSL $VERSION"
 
-PACKAGE_VERSION=$(python -c 'from pathlib import Path; ns = {}; exec(Path("indsl/_version.py").read_text(), ns); print(ns["__version__"])')
+PACKAGE_VERSION=$(uv run python -c 'from pathlib import Path; ns = {}; exec(Path("indsl/_version.py").read_text(), ns); print(ns["__version__"])')
 if [ "$PACKAGE_VERSION" != "$VERSION" ]; then
     echo "Error: pyproject.toml version ($VERSION) does not match indsl/_version.py ($PACKAGE_VERSION)."
     exit 1
@@ -64,6 +64,7 @@ cleanup() {
 trap cleanup EXIT
 
 awk -v tag="$TAG" '
+    { sub(/\r$/, "") }
     function is_target_header(line) {
         return line == "## " tag || index(line, "## " tag " ") == 1 || index(line, "## [" tag "]") == 1
     }

--- a/publish_library.sh
+++ b/publish_library.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Creates the release tag on main and creates the GitHub release after the version bump PR is merged.
+# Run this from the repo root after the bump-version PR has been merged into main.
+#
+# Usage: bash publish_library.sh
+# Requires: gh CLI authenticated
+
+if ! command -v gh >/dev/null 2>&1; then
+    echo "Error: gh CLI is required."
+    exit 1
+fi
+
+if ! gh auth status >/dev/null 2>&1; then
+    echo "Error: gh CLI is not authenticated."
+    exit 1
+fi
+
+if ! git diff --quiet || ! git diff --cached --quiet; then
+    echo "Error: tracked files have uncommitted changes."
+    exit 1
+fi
+
+git fetch origin main --tags
+git checkout main
+git pull --ff-only
+
+LOCAL_MAIN=$(git rev-parse HEAD)
+REMOTE_MAIN=$(git rev-parse origin/main)
+if [ "$LOCAL_MAIN" != "$REMOTE_MAIN" ]; then
+    echo "Error: local main does not match origin/main."
+    exit 1
+fi
+
+VERSION=$(python -c 'import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["version"])')
+TAG="v$VERSION"
+TITLE="InDSL $VERSION"
+
+PACKAGE_VERSION=$(python -c 'from pathlib import Path; ns = {}; exec(Path("indsl/_version.py").read_text(), ns); print(ns["__version__"])')
+if [ "$PACKAGE_VERSION" != "$VERSION" ]; then
+    echo "Error: pyproject.toml version ($VERSION) does not match indsl/_version.py ($PACKAGE_VERSION)."
+    exit 1
+fi
+
+REMOTE_TAG_COMMIT=$(git ls-remote origin "refs/tags/$TAG^{}" | awk '{ print $1 }')
+if [ -z "$REMOTE_TAG_COMMIT" ]; then
+    REMOTE_TAG_COMMIT=$(git ls-remote origin "refs/tags/$TAG" | awk '{ print $1 }')
+fi
+
+PUSH_TAG=true
+if [ -n "$REMOTE_TAG_COMMIT" ]; then
+    if [ "$REMOTE_TAG_COMMIT" != "$LOCAL_MAIN" ]; then
+        echo "Error: remote tag $TAG already exists but does not point to origin/main."
+        exit 1
+    fi
+    PUSH_TAG=false
+fi
+
+NOTES_FILE=$(mktemp)
+cleanup() {
+    rm -f "$NOTES_FILE"
+}
+trap cleanup EXIT
+
+awk -v tag="$TAG" '
+    function is_target_header(line) {
+        return line == "## " tag || index(line, "## " tag " ") == 1 || index(line, "## [" tag "]") == 1
+    }
+    /^## / && in_section && !is_target_header($0) { exit }
+    is_target_header($0) { in_section = 1 }
+    in_section { print }
+' CHANGELOG.md > "$NOTES_FILE"
+
+if [ ! -s "$NOTES_FILE" ]; then
+    echo "Error: could not find release notes for $TAG in CHANGELOG.md."
+    exit 1
+fi
+
+if gh release view "$TAG" >/dev/null 2>&1; then
+    echo "Error: GitHub release $TAG already exists."
+    exit 1
+fi
+
+if [ "$PUSH_TAG" = true ]; then
+    git tag --annotate --force "$TAG" --message "$TITLE" HEAD
+
+    echo "Pushing tag $TAG to origin at $(git rev-parse --short HEAD)..."
+    git push origin "refs/tags/$TAG:refs/tags/$TAG"
+else
+    echo "Remote tag $TAG already points to origin/main; creating the missing release."
+fi
+
+RELEASE_ARGS=(--title "$TITLE" --notes-file "$NOTES_FILE" --verify-tag)
+if [[ "$VERSION" =~ (a|b|rc)[0-9]+ ]]; then
+    RELEASE_ARGS+=(--prerelease)
+fi
+
+echo "Creating GitHub release $TAG..."
+gh release create "$TAG" "${RELEASE_ARGS[@]}"
+
+echo ""
+echo "Done. Release $TAG published; PyPI publish workflow triggered."


### PR DESCRIPTION
## Summary

Fixes the release workflow so tags are only pushed to GitHub after the version bump PR has merged into `main`, preventing bypass of GitHub ref protection rules (which was triggering SecBot security alerts on every release).

## Root cause

The previous `PUBLISHING.md` instructed running `git push origin --tags` before the PR was merged. This pushed a tag pointing to a commit on `bump-version` (not yet on `main`), which GitHub logged as a ref protection bypass — the source of the SecBot alerts.

## Changes

- **`bump_library.sh`**: Commitizen creates a local tag during `cz bump`; the script now deletes it immediately so it cannot be accidentally pushed before merge
- **`publish_library.sh`**: New post-merge script — checks out latest `main`, validates version file consistency, creates an annotated tag on the merged commit, pushes it, and creates the GitHub release from `CHANGELOG.md`
- **`publish.yaml`**: Adds CI-side validation that the release tag is an ancestor of `main` and that version files are consistent; adds concurrency group; removes `dunamai`-based version rewriting in favour of explicit validation
- **`PUBLISHING.md`**: Rewritten to reflect the new workflow with `publish_library.sh`
- **`CONTRIBUTING.md`**: Adds a pointer to `PUBLISHING.md` for the release workflow

## Test plan

- [ ] Run `bash bump_library.sh` and confirm the local tag is deleted after the bump commit is created
- [ ] After next release PR merges, run `bash publish_library.sh` and confirm tag is pushed and GitHub release is created without SecBot alerts
- [ ] Confirm `publish.yaml` fails if the tag does not point to a `main` ancestor