### PR TITLE
ci: allow manual workflow_dispatch trigger for docs deploy

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -3,6 +3,7 @@ name: Build and deploy docs
 on:
   release:
     types: [created]
+  workflow_dispatch:
   pull_request:
     paths:
       - 'docs-source/**'
@@ -53,7 +54,7 @@ jobs:
 
   deploy:
     needs: build
-    if: github.event_name == 'release'
+    if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     name: Deploy to GitHub Pages
     permissions:


### PR DESCRIPTION
## Summary
- Adds `workflow_dispatch` trigger to the docs workflow so it can be run manually from `main`
- Extends the deploy job condition to also fire on `workflow_dispatch` (was release-only)

## Why
The `github-pages` environment protection rules require the deploying ref to be on `main`. If a release tag was pushed before the PR was merged (pointing to a pre-merge commit), the automated deploy fails with "Tag is not allowed to deploy to github-pages due to environment protection rules." This manual trigger provides a fallback to deploy docs from `main` without needing admin intervention.

## Test plan
- [ ] Merge this PR
- [ ] Go to Actions → "Build and deploy docs" → "Run workflow" → select `main`
- [ ] Confirm docs deploy to https://indsl.docs.cognite.com/ succeeds